### PR TITLE
Setup the package for multiple exports

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,16 +1,5 @@
-import * as fs from "javy/fs";
-
 // This package name will be aliased to the file provided by the user.
 import * as userFunction from "user-function";
+import run from "./run";
 
-export type ShopifyFunction<Input extends {}, Output extends {}> = (
-  input: Input
-) => Output;
-
-const input_data = fs.readFileSync(fs.STDIO.Stdin);
-const input_str = new TextDecoder("utf-8").decode(input_data);
-const input_obj = JSON.parse(input_str);
-const output_obj = userFunction?.default(input_obj);
-const output_str = JSON.stringify(output_obj);
-const output_data = new TextEncoder().encode(output_str);
-fs.writeFileSync(fs.STDIO.Stdout, output_data);
+run(userFunction?.default)

--- a/package.json
+++ b/package.json
@@ -16,5 +16,8 @@
     "@graphql-codegen/typescript-operations": "^2.5.5",
     "graphql": "^16.6.0",
     "typescript": "^4.8.4"
+  },
+  "peerDependencies": {
+    "javy": "^0.1.0"
   }
 }

--- a/run.ts
+++ b/run.ts
@@ -1,0 +1,15 @@
+import * as fs from "javy/fs";
+
+export type ShopifyFunction<Input extends {}, Output extends {}> = (
+  input: Input
+) => Output;
+
+export default function <I extends {}, O extends {}>(userfunction: ShopifyFunction<I, O>) {
+  const input_data = fs.readFileSync(fs.STDIO.Stdin);
+  const input_str = new TextDecoder("utf-8").decode(input_data);
+  const input_obj = JSON.parse(input_str);
+  const output_obj = userfunction(input_obj);
+  const output_str = JSON.stringify(output_obj);
+  const output_data = new TextEncoder().encode(output_str);
+  fs.writeFileSync(fs.STDIO.Stdout, output_data);
+}


### PR DESCRIPTION
We want to leverage Javy's new multi-export feature. This commit helps by:
1. Extracting the logic for running a function (stream & JSON handling) to a `run` function that can be used without `index.ts`.
2. Making `javy` a peerDependency so that it's still accessible for `run`, (without using any file here as esbuild's entrypoint).

#gsd:34464