### PR TITLE
Add new Javy JSON builtins

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org/"
   },
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "",
   "main": "index.ts",
   "keywords": [],
@@ -18,6 +18,5 @@
     "typescript": "^4.8.4"
   },
   "peerDependencies": {
-    "javy": "^0.1.0"
   }
 }

--- a/run.ts
+++ b/run.ts
@@ -1,15 +1,22 @@
-import * as fs from "javy/fs";
-
 export type ShopifyFunction<Input extends {}, Output extends {}> = (
   input: Input
 ) => Output;
 
+
+interface Javy {
+  JSON: {
+    fromStdin(): any;
+    toStdout(val: any);
+  }
+}
+
+declare global {
+  const Javy: Javy;
+}
+
+
 export default function <I extends {}, O extends {}>(userfunction: ShopifyFunction<I, O>) {
-  const input_data = fs.readFileSync(fs.STDIO.Stdin);
-  const input_str = new TextDecoder("utf-8").decode(input_data);
-  const input_obj = JSON.parse(input_str);
+  const input_obj = Javy.JSON.fromStdin();
   const output_obj = userfunction(input_obj);
-  const output_str = JSON.stringify(output_obj);
-  const output_data = new TextEncoder().encode(output_str);
-  fs.writeFileSync(fs.STDIO.Stdout, output_data);
+  Javy.JSON.toStdout(output_obj);
 }


### PR DESCRIPTION
This commit introduces the usage of the the new `Javy.JSON` builtins.

Also bumps the version and removes the dependency on the `javy` npm package as nothing from that package is consumed in this version anymore.

Opted to introduce the TypeScript definition in this package instead of including a .d.ts file in the `javy` npm package given the reason stated in the previous paragraph.

I'm still in the process of 🎩 this, but it's ready for general review. 