### PR TITLE
docs: fix contributing guide (link correct project)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ We love receiving pull requests!
 
 ## How to contribute
 
-1. Fork it ( https://github.com/Shopify/shopify-function-rust/fork )
+1. Fork it ( https://github.com/Shopify/shopify-function-javascript/fork )
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)


### PR DESCRIPTION
Just a tiny doc tweak I spotted while looking around the repo for other reasons -- looks like a copypaste from the Rust function repo.