### PR TITLE
Introduce Javy.JSON builtins

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org/"
   },
-  "version": "0.3.0",
+  "version": "1.0.0",
   "description": "",
   "main": "index.ts",
   "keywords": [],
@@ -16,8 +16,5 @@
     "@graphql-codegen/typescript-operations": "^2.5.5",
     "graphql": "^16.6.0",
     "typescript": "^4.8.4"
-  },
-  "peerDependencies": {
-    "javy": "^0.1.0"
   }
 }

--- a/run.ts
+++ b/run.ts
@@ -1,15 +1,20 @@
-import * as fs from "javy/fs";
-
 export type ShopifyFunction<Input extends {}, Output extends {}> = (
   input: Input
 ) => Output;
 
+interface Javy {
+  JSON: {
+    fromStdin(): any;
+    toStdout(val: any);
+  }
+}
+
+declare global {
+  const Javy: Javy;
+}
+
 export default function <I extends {}, O extends {}>(userfunction: ShopifyFunction<I, O>) {
-  const input_data = fs.readFileSync(fs.STDIO.Stdin);
-  const input_str = new TextDecoder("utf-8").decode(input_data);
-  const input_obj = JSON.parse(input_str);
+  const input_obj = Javy.JSON.fromStdin();
   const output_obj = userfunction(input_obj);
-  const output_str = JSON.stringify(output_obj);
-  const output_data = new TextEncoder().encode(output_str);
-  fs.writeFileSync(fs.STDIO.Stdout, output_data);
+  Javy.JSON.toStdout(output_obj)
 }


### PR DESCRIPTION
This commit introduces `Javy.JSON` builtins and bumps the package version to 1.0.0.

It's important to note that this is a breaking change because it introduces new JavaScript builtins for faster JSON parsing and stringifying from stdin and to stdout.

In order to use v1.0.0 of this package, users need the latest shopify cli, which contains `javy` v3.1.0

# 🎩 

- Create a new extension with this branch of Shopify's CLI https://github.com/Shopify/cli/pull/4444
- Manually substitute the `@shopify/shopify_functionv0.1.0` in the package.json, with a GitHub dependency (`"@shopify/shopify_function": "saulecabrera/shopify-function-javascript#javy-json-v1"`) or a local dependency (by cloning my repo and switching to this branch)
- Build and run the extension