### PR TITLE
Revert "move @graphql-codegen/* to devdeps"

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,12 +11,10 @@
   "author": "Surma <surma@shopify.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "graphql": "^16.6.0",
-    "typescript": "^4.8.4"
-  },
-  "devDependencies": {
     "@graphql-codegen/cli": "^2.13.7",
     "@graphql-codegen/typescript": "^2.8.0",
-    "@graphql-codegen/typescript-operations": "^2.5.5"
+    "@graphql-codegen/typescript-operations": "^2.5.5",
+    "graphql": "^16.6.0",
+    "typescript": "^4.8.4"
   }
 }


### PR DESCRIPTION
Reverts Shopify/shopify-function-javascript#15
Related issue: https://github.com/Shopify/shopify-functions/issues/414

The GraphQL dependencies are actually used by consumers outside of the package to build functions.