### PR TITLE
lock graphql-tools/url-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org/"
   },
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "",
   "main": "index.ts",
   "keywords": [],
@@ -14,6 +14,7 @@
     "@graphql-codegen/cli": "^5.0.4",
     "@graphql-codegen/typescript": "^4.1.3",
     "@graphql-codegen/typescript-operations": "^4.4.1",
+    "@graphql-tools/url-loader": "8.0.16",
     "graphql": "^16.6.0",
     "typescript": "^5.7.3"
   }


### PR DESCRIPTION
Follow up to https://github.com/Shopify/shopify-function-javascript/pull/27

When we bumped `@graphql-codegen/cli`, our packages ends up bumping the following:
```bash
npm list graphql-ws
@shopify/shopify_function@1.0.4 /Users/lopert/src/github.com/Shopify/shopify-function-javascript
└─┬ @graphql-codegen/cli@5.0.4
  └─┬ @graphql-tools/url-loader@8.0.26
    └─┬ @graphql-tools/executor-graphql-ws@2.0.1
      └── graphql-ws@6.0.3
```

However, `graphql-ws` [stopped supporting node 18 in v6](https://github.com/enisdenjo/graphql-ws/pull/613), but we need to keep support for it for the CLI.

If we lock `@graphql-tools/url-loader@8.0.16`, [as done over here](https://github.com/Shopify/shopify-app-template-remix/pull/962), we get the following list

```bash
npm list graphql-ws
@shopify/shopify_function@1.0.5 /Users/lopert/src/github.com/Shopify/shopify-function-javascript
└─┬ @graphql-tools/url-loader@8.0.16
  └─┬ @graphql-tools/executor-graphql-ws@1.3.7
    └── graphql-ws@5.16.2
```

# Tophat 🎩 
Using Node 18.

## In this repo
I tried using `npm link` but was not successful, so instead went with the tarball approach.
```
npm install
npm pack
```

## In an app directory
Add the tarball to app dependencies.
```
npm add /path/to/shopify-function-javascript/shopify-shopify_function-1.0.5.tgz
```

## In local CLI
Run the command to generate a new extension. Not sure if this actually needs to be run from a local CLI now that I think about it.

```
pnpm shopify app generate extension --template order_discounts --flavor vanilla-js --path=/path/to/app/ssf-fix
```