### PR TITLE
Lock graphql config dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org/"
   },
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "",
   "main": "index.ts",
   "keywords": [],


### PR DESCRIPTION
Started seeing [CLI failures](https://shopify.slack.com/archives/C030LHFCA5T/p1744645562768389) related to a [node engine failure](https://shopify.slack.com/archives/C030LHFCA5T/p1744645637952059?thread_ts=1744645562.768389&cid=C030LHFCA5T) for version 18, similar to what I fixed in https://github.com/Shopify/shopify-function-javascript/pull/30.

The latest version of Minimatch (10) now [requires node 20 or higher](https://github.com/isaacs/minimatch/blob/main/changelog.md#100).
This doesn't work for us because we need CLI to run under node 18.

We can see using `npm why` that we're getting this through graphql-config
```bash
 ~/s/gi/S/shopify-function-javascript  main *1  nvm use 18                                         ✔  system   
Now using node v18.20.8 (npm v10.8.2)

 ~/s/gi/S/shopify-function-javascript  main *1  npm install                                                    ✔ 
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: 'minimatch@10.0.1',
npm warn EBADENGINE   required: { node: '20 || >=22' },
npm warn EBADENGINE   current: { node: 'v18.20.8', npm: '10.8.2' }
npm warn EBADENGINE }

added 327 packages, and audited 328 packages in 4s

44 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities

 ~/s/gi/S/shopify-function-javascript  main *1  npm why minimatch                                         ✔  4s 
minimatch@10.0.1
node_modules/minimatch
  minimatch@"^10.0.0" from graphql-config@5.1.4
  node_modules/graphql-config
    graphql-config@"^5.1.1" from @graphql-codegen/cli@5.0.5
    node_modules/@graphql-codegen/cli
      @graphql-codegen/cli@"^5.0.4" from the root project
```

The minimatch dependency was bumped in [graphql-config in 5.1.4](https://github.com/graphql-hive/graphql-config/releases/tag/v5.1.4), so we're locking it back down to 5.1.3.

Additionally, since this is the second time we've run into an issue like this, I've gone ahead and swapped all our package version to use specific versions. I used the versions that ended up in the `package-lock.json` after a successful `npm install`.