### PR TITLE
Update globals for usage with plugin v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "access": "public",
     "@shopify:registry": "https://registry.npmjs.org/"
   },
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "",
   "main": "index.ts",
   "keywords": [],

--- a/run.ts
+++ b/run.ts
@@ -1,23 +1,26 @@
-export type ShopifyFunction<Input extends {}, Output extends {}> = (
+export type UserFunction<Input extends {}, Output extends {}> = (
   input: Input
 ) => Output;
 
-interface Javy {
-  JSON: {
-    fromStdin(): any;
-    toStdout(val: any);
-  }
+interface ShopifyFunction {
+  readInput(): any;
+  writeOutput(val: any);
 }
 
 declare global {
-  const Javy: Javy;
+  const ShopifyFunction: ShopifyFunction;
 }
 
-export default function <I extends {}, O extends {}>(userfunction: ShopifyFunction<I, O>) {
-  if (!Javy.JSON) {
-    throw new Error('Javy.JSON is not defined. Please rebuild your function using the latest version of Shopify CLI.');
+export default function <I extends {}, O extends {}>(
+  userfunction: UserFunction<I, O>
+) {
+  if (!ShopifyFunction) {
+    throw new Error(
+      "ShopifyFunction is not defined. Please rebuild your function using the latest version of Shopify CLI."
+    );
   }
-  const input_obj = Javy.JSON.fromStdin();
+
+  const input_obj = ShopifyFunction.readInput();
   const output_obj = userfunction(input_obj);
-  Javy.JSON.toStdout(output_obj)
+  ShopifyFunction.writeOutput(output_obj);
 }

--- a/run.ts
+++ b/run.ts
@@ -14,7 +14,9 @@ declare global {
 export default function <I extends {}, O extends {}>(
   userfunction: UserFunction<I, O>
 ) {
-  if (!ShopifyFunction) {
+  try {
+    ShopifyFunction;
+  } catch (e) {
     throw new Error(
       "ShopifyFunction is not defined. Please rebuild your function using the latest version of Shopify CLI."
     );


### PR DESCRIPTION
Part of https://github.com/shop/issues-shopifyvm/issues/29

Do not merge yet
 - Will require coordinating with a CLI update
 - Requires a version bump. Probably ~~major~~ at least minor to avoid having older/existing CLI client/extensions pulling this in ([the dep](https://github.com/Shopify/cli/blob/04477bad4c6a7ce3ba449ddfe0cc18ad4de53f6d/packages/app/src/cli/services/generate/extension.ts#L315-L319) is [~tilde](https://betterstack.com/community/questions/difference-between-tilde-and-caret-in-package-json/#:~:text=The%20tilde%20prefix%20(~)%20indicates%20that%20the%20tilde%20symbol%20will%20match%20the%20most%20recent%20patch%20version%20or%20the%20most%20recent%20minor%20version%2C%20i.e.%2C%20the%20middle%20number.%20For%20example%2C%20~1.2.3%20will%20match%20all%201.2.x%20but%20not%201.3.x%20versions.)) and attempting to use it with plugin v1

Updates the globals to use `ShopifyFunction` instead of `Javy.JSON`.
