### PR TITLE
downgrade graphql-config

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@graphql-codegen/cli": "5.0.5",
     "@graphql-codegen/typescript": "4.1.6",
-    "graphql-config": "5.1.4",
+    "graphql-config": "5.1.3",
     "@graphql-codegen/typescript-operations": "4.6.0",
     "@graphql-tools/url-loader": "8.0.16",
     "graphql": "16.10.0",


### PR DESCRIPTION
`graphql-config` needs to be at `5.1.3`, because `5.1.4` is not compatible with node 18, which we need to support in the CLI.

I previously attempted to [lock us to 5.1.3](https://github.com/Shopify/shopify-function-javascript/pull/32) but [dependabot opened a PR](https://github.com/Shopify/shopify-function-javascript/pull/33) anyways. See [my PR for the full context](https://github.com/Shopify/shopify-function-javascript/pull/33).

I tested `npm install` with the current main (aka with `5.1.4`) and got the same error. 

```
> npm install                                                  ✔ 
npm error code EBADENGINE
npm error engine Unsupported engine
npm error engine Not compatible with your version of node/npm: minimatch@10.0.1
npm error notsup Not compatible with your version of node/npm: minimatch@10.0.1
npm error notsup Required: {"node":"20 || >=22"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v18.20.8"}
```

**Next steps**
- Hopefully dependabot attempt to re-upgrade this again, and I can mark this dependency as ignored.
- I'll create an issue in this repo for adding a node 18 test to CI to catch future bumps that may break node 18.
