### PR TITLE
Adding backwards compatibility with JSON

### DIFF
--- a/run.ts
+++ b/run.ts
@@ -2,27 +2,37 @@ export type UserFunction<Input extends {}, Output extends {}> = (
   input: Input
 ) => Output;
 
+interface Javy {
+  JSON: {
+    fromStdin(): any;
+    toStdout(val: any);
+  }
+}
+
 interface ShopifyFunction {
   readInput(): any;
   writeOutput(val: any);
 }
 
 declare global {
+  const Javy: Javy;
   const ShopifyFunction: ShopifyFunction;
 }
 
 export default function <I extends {}, O extends {}>(
   userfunction: UserFunction<I, O>
 ) {
-  try {
-    ShopifyFunction;
-  } catch (e) {
+  if (Javy.JSON) {
+    const input_obj = Javy.JSON.fromStdin();
+    const output_obj = userfunction(input_obj);
+    Javy.JSON.toStdout(output_obj);
+  } else if (ShopifyFunction) {
+    const input_obj = ShopifyFunction.readInput();
+    const output_obj = userfunction(input_obj);
+    ShopifyFunction.writeOutput(output_obj);
+  } else {
     throw new Error(
       "ShopifyFunction is not defined. Please rebuild your function using the latest version of Shopify CLI."
     );
   }
-
-  const input_obj = ShopifyFunction.readInput();
-  const output_obj = userfunction(input_obj);
-  ShopifyFunction.writeOutput(output_obj);
 }


### PR DESCRIPTION
We removed globals for JAVY JSON in https://github.com/Shopify/shopify-function-javascript/commit/62a55c508ce3d7ee0d483b2a4adddcaad18cfa69?w=1 , this PR adds it back to ensure backwards compatibility. 