### PR TITLE
No-op - Pinning github actions to commit SHAs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         run: npm install
 
       - name: Create Release Pull Request or Publish
-        uses: changesets/action@v1 # Must use latest version!
+        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1
         with:
           publish: npx changeset publish
         env:

--- a/.github/workflows/snapit.yml
+++ b/.github/workflows/snapit.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Checkout default branch
         uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10
       - name: Create snapshot version


### PR DESCRIPTION
## Why?

By using `some-org/some-action@v3` you are trusting a mutable tag. If the upstream repo is compromised, a force-pushed `v3` ships malicious code into your workflow on the next run — see [tj-actions/changed-files (March 2025)](https://www.cisa.gov/news-events/alerts/2025/03/18/supply-chain-compromise-third-party-github-action-cve-2025-30066) for recent real-world cases that leaked secrets across thousands of downstream workflows.

Pinning to a full 40-char SHA (`uses: tj-actions/changed-files@<sha> # v45.0.3`) makes the reference immutable and helps to mitigate this type of supply chain attacks.


cc @lopert @saga-dasgupta for review.